### PR TITLE
initial api spec completed with test coverage

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -416,9 +416,41 @@ semver_compare() {
         # majors don't match, no further verification needed
         return 1
       # major matches, check minor
-      elif [ $left_minor -ge $right_minor ]; then
-        # minor A is ~> minor B
+      elif [ $left_minor -gt $right_minor ]; then
+        # minor A is > minor B
         return 0
+      elif [ $left_minor -eq $right_minor ]; then
+        # minor matches, check patch
+        if [ $left_patch -gt $right_patch ]; then
+          return 0
+        elif [ $left_patch -lt $right_patch ]; then
+          # left patch < right patch
+          return 1
+        elif [ $left_patch -eq $right_patch ]; then
+          # patch matches, check special
+          # special is considered a 'lesser' version than
+          # a version without a special (e.g. 1.0.0 is assumed newer than 1.0.0-alpha)
+          if [ "_$left_special"  == "_" ] && [ "_$right_special"  == "_" ]; then
+            # both specials are empty, versions match
+            return 0
+          elif [ "_$left_special"  == "_" ] && [ "_$right_special"  != "_" ]; then
+            # left version does not have special, right version does
+            return 0
+          elif [ "_$left_special"  != "_" ] && [ "_$right_special"  == "_" ]; then
+            # left version has special, right version does not
+            return 1
+          elif [ "_$left_special" "<" "_$right_special" ]; then
+            # left version special is ASCII less-than right version special
+            return 1
+          elif [ "_$left_special" ">" "_$right_special" ]; then
+            # left version special is ASCII greater-than right version special
+            return 0
+          elif [ "_$left_special" == "_$right_special" ]; then
+            # left version special matches right version special
+            # this must be tested after doing the 'empty' test above
+            return 0
+          fi
+        fi
       elif [ $left_minor -lt $right_minor ]; then
         # minor A is < minor B
         return 1

--- a/tests/compare-1-test.sh
+++ b/tests/compare-1-test.sh
@@ -25,7 +25,7 @@ describe "compare-invalid-type"
 #
 
 # ------------------------------
-# X.X.X ?? X.X.X
+# X.X.X ?? X.X.X ?
 # ------------------------------
 it_errors_when_comparison_type_invalid() {
   error_output=$(rerun semver: compare \

--- a/tests/compare-10-test.sh
+++ b/tests/compare-10-test.sh
@@ -20,39 +20,9 @@ describe "compare-release-less-than-rc"
 #
 
 # ------------------------------
-# X.X.(Y) < X.X.(X)-B
+# X.X.X < X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_lt_rc_ver_patch() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE"
-}
-
-# ------------------------------
-# X.(Y).X < X.(X).X-B
-# ------------------------------
-it_ret0_when_rel_ver_lt_rc_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE"
-}
-
-# ------------------------------
-# (Y).X.X < (Z).X.X-B
-# ------------------------------
-it_ret0_when_rel_ver_lt_rc_ver_major() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.X.X !< X.X.X-(B)
-# ------------------------------
-it_ret1_when_rel_ver_notlt_rc_ver_special() {
+it_ret1_when_rel_ver_gt_rc_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -67,9 +37,19 @@ it_ret1_when_rel_ver_notlt_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y) !< X.X.(Z)-B
+# X.X.(1) < X.X.(2)-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_notlt_rc_ver_patch() {
+it_ret0_when_rel_patch_ver_lt_rc_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE"
+}
+
+# ------------------------------
+# X.X.(2) < X.X.(1)-Z ?
+# ------------------------------
+it_ret1_when_rel_patch_ver_gt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
@@ -84,9 +64,19 @@ it_ret1_when_rel_ver_notlt_rc_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X !< X.(Z).X-B
+# X.(1).X < X.(2).X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_notlt_rc_ver_minor() {
+it_ret0_when_rel_minor_ver_lt_rc_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.(2).X < X.(1).X-Z ?
+# ------------------------------
+it_ret1_when_rel_minor_ver_gt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
@@ -101,9 +91,19 @@ it_ret1_when_rel_ver_notlt_rc_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X !< (Z).X.X-B
+# (1).X.X < (2).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_notlt_rc_ver_major() {
+it_ret0_when_rel_major_ver_lt_rc_major_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# (2).X.X < (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rel_major_ver_gt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \

--- a/tests/compare-11-test.sh
+++ b/tests/compare-11-test.sh
@@ -20,9 +20,9 @@ describe "compare-rc-less-than-release"
 #
 
 # ------------------------------
-# X.X.X-(A) < X.X.X
+# X.X.X-Z < X.X.X ?
 # ------------------------------
-it_ret0_when_rc_ver_lt_rel_ver_special() {
+it_ret0_when_rc_ver_lt_rel_ver() {
   rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "lt" \
@@ -30,9 +30,9 @@ it_ret0_when_rc_ver_lt_rel_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A < X.X.(X)
+# X.X.(1)-Z < X.X.(2) ?
 # ------------------------------
-it_ret0_when_rc_ver_lt_rel_ver_patch() {
+it_ret0_when_rc_patch_ver_lt_rel_patch_ver() {
   rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "lt" \
@@ -40,29 +40,9 @@ it_ret0_when_rc_ver_lt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A < X.(X).X
+# X.X.(2)-Z < X.X.(1) ?
 # ------------------------------
-it_ret0_when_rc_ver_lt_rel_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "lt" \
-    --right_version "$RELEASE_VERSION_TWO_SIX_SIX"
-}
-
-# ------------------------------
-# (Y).X.X-A < (Z).X.X
-# ------------------------------
-it_ret0_when_rc_ver_lt_rel_ver_major() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "lt" \
-    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX"
-}
-
-# ------------------------------
-# X.X.(Y)-A !< X.X.(Z)
-# ------------------------------
-it_ret1_when_rc_ver_notlt_rel_ver_patch() {
+it_ret1_when_rc_patch_ver_gt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
@@ -77,9 +57,19 @@ it_ret1_when_rc_ver_notlt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A !< X.(Z).X
+# X.(1).X-Z < X.(2).X ?
 # ------------------------------
-it_ret1_when_rc_ver_notlt_rel_ver_minor() {
+it_ret0_when_rc_minor_ver_lt_rel_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_TWO_SIX_SIX"
+}
+
+# ------------------------------
+# X.(2).X-Z < X.(1).X ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_gt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
@@ -94,9 +84,19 @@ it_ret1_when_rc_ver_notlt_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A !< (Z).X.X
+# (1).X.X-Z < (2).X.X ?
 # ------------------------------
-it_ret1_when_rc_ver_notlt_rel_ver_major() {
+it_ret0_when_rc_major_ver_lt_rel_major_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX"
+}
+
+# ------------------------------
+# (2).X.X-Z < (1).X.X ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \

--- a/tests/compare-12-test.sh
+++ b/tests/compare-12-test.sh
@@ -20,39 +20,26 @@ describe "compare-release-greater-than-release"
 #
 
 # ------------------------------
-# X.X.(Y) > X.X.(Z)
+# X.X.X > X.X.X ?
 # ------------------------------
-it_ret0_when_rel_ver_gt_rel_ver_patch() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
+it_ret1_when_rel_ver_eq_rel_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
 }
 
 # ------------------------------
-# X.(Y).X > X.(Z).X
+# X.X.(1) > X.X.(2) ?
 # ------------------------------
-it_ret0_when_rel_ver_gt_rel_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
-}
-
-# ------------------------------
-# (Y).X.X > (Z).X.X
-# ------------------------------
-it_ret0_when_rel_ver_gt_rel_ver_major() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
-}
-
-# ------------------------------
-# X.X.(Y) !> X.X.(Z)
-# ------------------------------
-it_ret1_when_rel_ver_notgt_rel_ver_patch() {
+it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -67,9 +54,19 @@ it_ret1_when_rel_ver_notgt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X !> X.(Z).X
+# X.X.(2) > X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_ver_notgt_rel_ver_minor() {
+it_ret0_when_rel_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+}
+
+# ------------------------------
+# X.(1).X > X.(2).X ?
+# ------------------------------
+it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -84,9 +81,19 @@ it_ret1_when_rel_ver_notgt_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X > (Z).X.X
+# X.(2).X > X.(1).X ?
 # ------------------------------
-it_ret1_when_rel_ver_notgt_rel_ver_major() {
+it_ret0_when_rel_minor_ver_gt_rel_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+}
+
+# ------------------------------
+# (1).X.X > (2).X.X ?
+# ------------------------------
+it_ret1_when_rel_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -98,4 +105,14 @@ it_ret1_when_rel_ver_notgt_rel_ver_major() {
   } || {
     echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
   }
+}
+
+# ------------------------------
+# (2).X.X > (1).X.X ?
+# ------------------------------
+it_ret0_when_rel_major_ver_gt_rel_major_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }

--- a/tests/compare-13-test.sh
+++ b/tests/compare-13-test.sh
@@ -20,49 +20,26 @@ describe "compare-rc-greater-than-rc"
 #
 
 # ------------------------------
-# X.X.X-(A) > X.X.X-(B)
+# X.X.X-Z > X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rc_ver_gt_rc_ver_special() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
+it_ret1_when_rc_ver_eq_rc_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
 }
 
 # ------------------------------
-# X.X.(Y)-A > X.X.(Z)-B
+# X.X.X-(1) > X.X.X-(2) ?
 # ------------------------------
-it_ret0_when_rc_ver_gt_rc_ver_patch() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.(Y).X-A > X.(Z).X-B
-# ------------------------------
-it_ret0_when_rc_ver_gt_rc_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# (Y).X.X-A > (Z).X.X-B
-# ------------------------------
-it_ret0_when_rc_ver_gt_rc_ver_major() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.X.X-(A) !> X.X.X-(B)
-# ------------------------------
-it_ret1_when_rc_ver_notgt_rc_ver_special() {
+it_ret1_when_rc_special_ver_lt_rc_special_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -77,9 +54,19 @@ it_ret1_when_rc_ver_notgt_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A !> X.X.(Z)-B
+# X.X.X-(2) > X.X.X-(1) ?
 # ------------------------------
-it_ret1_when_rc_ver_notgt_rc_ver_patch() {
+it_ret0_when_rc_special_ver_gt_rc_special_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.X.(1)-Z > X.X.(2)-Z ?
+# ------------------------------
+it_ret1_when_rc_patch_ver_lt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -94,9 +81,19 @@ it_ret1_when_rc_ver_notgt_rc_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A !> X.(Z).X-B
+# X.X.(2)-Z > X.X.(1)-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_notgt_rc_ver_minor() {
+it_ret0_when_rc_patch_ver_gt_rc_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.(1).X-Z > X.(2).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -111,9 +108,19 @@ it_ret1_when_rc_ver_notgt_rc_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A !> (Z).X.X-B
+# X.(2).X-Z > X.(1).X-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_notgt_rc_ver_major() {
+it_ret0_when_rc_minor_ver_gt_rc_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# (1).X.X-Z > (2).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -125,4 +132,14 @@ it_ret1_when_rc_ver_notgt_rc_ver_major() {
   } || {
     echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
   }
+}
+
+# ------------------------------
+# (2).X.X-Z > (1).X.X-Z ?
+# ------------------------------
+it_ret0_when_rc_major_ver_gt_rc_major_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }

--- a/tests/compare-14-test.sh
+++ b/tests/compare-14-test.sh
@@ -20,44 +20,78 @@ describe "compare-release-greater-than-rc"
 #
 
 # ------------------------------
-# X.X.(Y) > X.X.(X)-B
+# X.X.X > X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_gt_rc_ver_patch() {
+it_ret0_when_rel_ver_gt_rc_ver() {
   rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.(Y).X > X.(X).X-B
+# X.X.(1) > X.X.(2)-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_gt_rc_ver_minor() {
+it_ret1_when_rel_patch_ver_lt_rc_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.(2) > X.X.(1)-Z ?
+# ------------------------------
+it_ret0_when_rel_patch_ver_gt_rc_patch_ver() {
   rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# (Y).X.X > (Z).X.X-B
+# X.(1).X > X.(2).X-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_gt_rc_ver_major() {
+it_ret1_when_rel_minor_ver_lt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(2).X > X.(1).X-Z ?
+# ------------------------------
+it_ret0_when_rel_minor_ver_gt_rc_minor_ver() {
   rerun semver: compare \
-    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.X.X !> X.X.X-(B)
+# (1).X.X > (2).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_notgt_rc_ver_special() {
+it_ret1_when_rel_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -67,52 +101,11 @@ it_ret1_when_rel_ver_notgt_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y) !> X.X.(Z)-B
+# (2).X.X > (1).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_notgt_rc_ver_patch() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+it_ret0_when_rel_major_ver_gt_rc_major_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
-}
-
-# ------------------------------
-# X.(Y).X !> X.(Z).X-B
-# ------------------------------
-it_ret1_when_rel_ver_notgt_rc_ver_minor() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
-}
-
-# ------------------------------
-# (Y).X.X !> (Z).X.X-B
-# ------------------------------
-it_ret1_when_rel_ver_notgt_rc_ver_major() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "gt" \
-    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }

--- a/tests/compare-15-test.sh
+++ b/tests/compare-15-test.sh
@@ -20,54 +20,14 @@ describe "compare-rc-greater-than-release"
 #
 
 # ------------------------------
-# X.X.X-(A) > X.X.X
+# X.X.X-Z > X.X.X ?
 # ------------------------------
-it_ret0_when_rc_ver_gt_rel_ver_special() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.X.(Y)-A > X.X.(X)
-# ------------------------------
-it_ret0_when_rc_ver_gt_rel_ver_patch() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.(Y).X-A > X.(X).X
-# ------------------------------
-it_ret0_when_rc_ver_gt_rel_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# (Y).X.X-A > (Z).X.X
-# ------------------------------
-it_ret0_when_rc_ver_gt_rel_ver_major() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.X.(Y)-A !> X.X.(Z)
-# ------------------------------
-it_ret1_when_rc_ver_notgt_rel_ver_patch() {
+it_ret1_when_rc_ver_lt_rel_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
-    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
+    --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -77,14 +37,14 @@ it_ret1_when_rc_ver_notgt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A !> X.(Z).X
+# X.X.(1)-Z > X.X.(2) ?
 # ------------------------------
-it_ret1_when_rc_ver_notgt_rel_ver_minor() {
+it_ret1_when_rc_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
-    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
+    --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -94,18 +54,65 @@ it_ret1_when_rc_ver_notgt_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A !> (Z).X.X
+# X.X.(2)-Z > X.X.(1) ?
 # ------------------------------
-it_ret1_when_rc_ver_notgt_rel_ver_major() {
+it_ret0_when_rc_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+}
+
+# ------------------------------
+# X.(1).X-Z > X.(2).X ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
-    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
+    --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
   } || {
     echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
   }
+}
+
+# ------------------------------
+# X.(2).X-Z > X.(1).X ?
+# ------------------------------
+it_ret0_when_rc_minor_ver_gt_rel_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+}
+
+# ------------------------------
+# (1).X.X-Z > (2).X.X ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rel_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X-Z > (1).X.X ?
+# ------------------------------
+it_ret0_when_rc_major_ver_gt_rel_major_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }

--- a/tests/compare-16-test.sh
+++ b/tests/compare-16-test.sh
@@ -13,30 +13,30 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-release-pess-patch-release"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess patch -- release versions
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X ~> X.X.X ?
 # ------------------------------
 it_ret0_when_rel_ver_eq_rel_ver() {
   rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1) ~> X.X.(2) ?
 # ------------------------------
 it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -47,30 +47,23 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2) ~> X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X ~> X.(2).X ?
 # ------------------------------
 it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -81,13 +74,13 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X ~> X.(1).X ?
 # ------------------------------
 it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -98,13 +91,13 @@ it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X ~> (2).X.X ?
 # ------------------------------
 it_ret1_when_rel_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -115,13 +108,13 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X ~> (1).X.X ?
 # ------------------------------
 it_ret1_when_rel_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-17-test.sh
+++ b/tests/compare-17-test.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env roundup
+#
+#/ usage:  rerun stubbs:test -m semver -p compare [--answers <>]
+#
+
+# Helpers
+# -------
+[[ -f ./functions.sh ]] && . ./functions.sh
+
+rerun() {
+  command $RERUN -M $RERUN_MODULES "$@"
+}
+
+# The Plan
+# --------
+describe "compare-rc-pess-patch-rc"
+
+#
+# comparison type: pess patch -- rc versions
+#
+
+# ------------------------------
+# X.X.X-Z ~> X.X.X-Z ?
+# ------------------------------
+it_ret0_when_rc_ver_eq_rc_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.X.X-(1) ~> X.X.X-(2) ?
+# ------------------------------
+it_ret1_when_rc_special_ver_lt_rc_special_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-(2) ~> X.X.X-(1) ?
+# ------------------------------
+it_ret0_when_rc_special_ver_gt_rc_special_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.X.(1)-Z ~> X.X.(2)-Z ?
+# ------------------------------
+it_ret1_when_rc_patch_ver_lt_rc_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.(2)-Z ~> X.X.(1)-Z ?
+# ------------------------------
+it_ret0_when_rc_patch_ver_gt_rc_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.(1).X-Z ~> X.(2).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(2).X-Z ~> X.(1).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_gt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (1).X.X-Z ~> (2).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X-Z ~> (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}

--- a/tests/compare-18-test.sh
+++ b/tests/compare-18-test.sh
@@ -13,31 +13,31 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-release-pess-patch-rc"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess patch -- left release version, right rc version
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X ~> X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_eq_rel_ver() {
+it_ret0_when_rel_ver_gt_rc_ver() {
   rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1) ~> X.X.(2)-Z ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
+it_ret1_when_rel_patch_ver_lt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -47,31 +47,24 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2) ~> X.X.(1)-Z ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_patch_ver_gt_rc_patch_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X ~> X.(2).X-Z ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
+it_ret1_when_rel_minor_ver_lt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -81,14 +74,14 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X ~> X.(1).X-Z ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
+it_ret1_when_rel_minor_ver_gt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -98,14 +91,14 @@ it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X ~> (2).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_major_ver_lt_rel_major_ver() {
+it_ret1_when_rel_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -115,14 +108,14 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X ~> (1).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_major_ver_gt_rel_major_ver() {
+it_ret1_when_rel_major_ver_gt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-19-test.sh
+++ b/tests/compare-19-test.sh
@@ -13,30 +13,37 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-rc-pess-patch-release"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess patch -- left rc version, right release version
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X-Z ~> X.X.X ?
 # ------------------------------
-it_ret0_when_rel_ver_eq_rel_ver() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+it_ret1_when_rc_ver_lt_rel_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1)-Z ~> X.X.(2) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
+it_ret1_when_rc_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -47,30 +54,23 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2)-Z ~> X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+it_ret0_when_rc_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X-Z ~> X.(2).X ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
+it_ret1_when_rc_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -81,13 +81,13 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X-Z ~> X.(1).X ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
+it_ret1_when_rc_minor_ver_gt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -98,13 +98,13 @@ it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X-Z ~> (2).X.X ?
 # ------------------------------
-it_ret1_when_rel_major_ver_lt_rel_major_ver() {
+it_ret1_when_rc_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -115,13 +115,13 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X-Z ~> (1).X.X ?
 # ------------------------------
-it_ret1_when_rel_major_ver_gt_rel_major_ver() {
+it_ret1_when_rc_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-2-test.sh
+++ b/tests/compare-2-test.sh
@@ -26,7 +26,7 @@ describe "compare-release-equals-release"
 #
 
 # ------------------------------
-# X.X.(Y) == X.X.(Y)
+# X.X.X == X.X.X ?
 # ------------------------------
 it_ret0_when_rel_ver_eq_rel_ver() {
   rerun semver: compare \
@@ -36,9 +36,9 @@ it_ret0_when_rel_ver_eq_rel_ver() {
 }
 
 # ------------------------------
-# X.X.(Y) != X.X.(Z)
+# X.X.(1) == X.X.(2) ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rel_ver_patch() {
+it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -53,9 +53,26 @@ it_ret1_when_rel_ver_noteq_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X != X.(Z).X
+# X.X.(2) == X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rel_ver_minor() {
+it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(1).X == X.(2).X ?
+# ------------------------------
+it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -70,14 +87,48 @@ it_ret1_when_rel_ver_noteq_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X != (Z).X.X
+# X.(2).X == X.(1).X ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rel_ver_major() {
+it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (1).X.X == (2).X.X ?
+# ------------------------------
+it_ret1_when_rel_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "eq" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X == (1).X.X ?
+# ------------------------------
+it_ret1_when_rel_major_ver_gt_rel_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-20-test.sh
+++ b/tests/compare-20-test.sh
@@ -13,30 +13,30 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-release-pess-minor-release"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess minor -- release versions
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X ~> X.X.X ?
 # ------------------------------
 it_ret0_when_rel_ver_eq_rel_ver() {
   rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1) ~> X.X.(2) ?
 # ------------------------------
 it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -47,30 +47,23 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2) ~> X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X ~> X.(2).X ?
 # ------------------------------
 it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -81,30 +74,23 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X ~> X.(1).X ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_minor_ver_gt_rel_minor_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X ~> (2).X.X ?
 # ------------------------------
 it_ret1_when_rel_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -115,13 +101,13 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X ~> (1).X.X ?
 # ------------------------------
 it_ret1_when_rel_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-21-test.sh
+++ b/tests/compare-21-test.sh
@@ -1,0 +1,145 @@
+#!/usr/bin/env roundup
+#
+#/ usage:  rerun stubbs:test -m semver -p compare [--answers <>]
+#
+
+# Helpers
+# -------
+[[ -f ./functions.sh ]] && . ./functions.sh
+
+rerun() {
+  command $RERUN -M $RERUN_MODULES "$@"
+}
+
+# The Plan
+# --------
+describe "compare-rc-pess-minor-rc"
+
+#
+# comparison type: pess minor -- rc versions
+#
+
+# ------------------------------
+# X.X.X-Z ~> X.X.X-Z ?
+# ------------------------------
+it_ret0_when_rc_ver_eq_rc_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.X.X-(1) ~> X.X.X-(2) ?
+# ------------------------------
+it_ret1_when_rc_special_ver_lt_rc_special_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-(2) ~> X.X.X-(1) ?
+# ------------------------------
+it_ret0_when_rc_special_ver_gt_rc_special_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.X.(1)-Z ~> X.X.(2)-Z ?
+# ------------------------------
+it_ret1_when_rc_patch_ver_lt_rc_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.(2)-Z ~> X.X.(1)-Z ?
+# ------------------------------
+it_ret0_when_rc_patch_ver_gt_rc_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.(1).X-Z ~> X.(2).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(2).X-Z ~> X.(1).X-Z ?
+# ------------------------------
+it_ret0_when_rc_minor_ver_gt_rc_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# (1).X.X-Z ~> (2).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X-Z ~> (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}

--- a/tests/compare-22-test.sh
+++ b/tests/compare-22-test.sh
@@ -13,31 +13,31 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-release-pess-minor-rc"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess minor -- left release version, right rc version
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X ~> X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rel_ver_eq_rel_ver() {
+it_ret0_when_rel_ver_gt_rc_ver() {
   rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1) ~> X.X.(2)-Z ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
+it_ret1_when_rel_patch_ver_lt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -47,31 +47,24 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2) ~> X.X.(1)-Z ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_patch_ver_gt_rc_patch_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X ~> X.(2).X-Z ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
+it_ret1_when_rel_minor_ver_lt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -81,31 +74,24 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X ~> X.(1).X-Z ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
-  local exitcode=
-  $(rerun semver: compare \
+it_ret0_when_rel_minor_ver_gt_rc_minor_ver() {
+  rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE"
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X ~> (2).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_major_ver_lt_rel_major_ver() {
+it_ret1_when_rel_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1
@@ -115,14 +101,14 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X ~> (1).X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_major_ver_gt_rel_major_ver() {
+it_ret1_when_rel_major_ver_gt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-23-test.sh
+++ b/tests/compare-23-test.sh
@@ -13,30 +13,37 @@ rerun() {
 
 # The Plan
 # --------
-describe "compare-release-equals-release"
+describe "compare-rc-pess-minor-release"
 
 #
-# comparison type: equals -- release versions
+# comparison type: pess minor -- left rc version, right release version
 #
 
 # ------------------------------
-# X.X.X == X.X.X ?
+# X.X.X-Z ~> X.X.X ?
 # ------------------------------
-it_ret0_when_rel_ver_eq_rel_ver() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
+it_ret1_when_rc_ver_lt_rel_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
 }
 
 # ------------------------------
-# X.X.(1) == X.X.(2) ?
+# X.X.(1)-Z ~> X.X.(2) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
+it_ret1_when_rc_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_EIGHT") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -47,30 +54,23 @@ it_ret1_when_rel_patch_ver_lt_rel_patch_ver() {
 }
 
 # ------------------------------
-# X.X.(2) == X.X.(1) ?
+# X.X.(2)-Z ~> X.X.(1) ?
 # ------------------------------
-it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+it_ret0_when_rc_patch_ver_gt_rel_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# X.(1).X == X.(2).X ?
+# X.(1).X-Z ~> X.(2).X ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
+it_ret1_when_rc_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_SIX_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -81,30 +81,23 @@ it_ret1_when_rel_minor_ver_lt_rel_minor_ver() {
 }
 
 # ------------------------------
-# X.(2).X == X.(1).X ?
+# X.(2).X-Z ~> X.(1).X ?
 # ------------------------------
-it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
-    --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 1
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
+it_ret0_when_rc_minor_ver_gt_rel_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX"
 }
 
 # ------------------------------
-# (1).X.X == (2).X.X ?
+# (1).X.X-Z ~> (2).X.X ?
 # ------------------------------
-it_ret1_when_rel_major_ver_lt_rel_major_ver() {
+it_ret1_when_rc_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
@@ -115,13 +108,13 @@ it_ret1_when_rel_major_ver_lt_rel_major_ver() {
 }
 
 # ------------------------------
-# (2).X.X == (1).X.X ?
+# (2).X.X-Z ~> (1).X.X ?
 # ------------------------------
-it_ret1_when_rel_major_ver_gt_rel_major_ver() {
+it_ret1_when_rc_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
-    --compare "eq" \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-3-test.sh
+++ b/tests/compare-3-test.sh
@@ -20,7 +20,7 @@ describe "compare-rc-equals-rc"
 #
 
 # ------------------------------
-# X.X.X-A == X.X.X-A
+# X.X.X-Z == X.X.X-Z ?
 # ------------------------------
 it_ret0_when_rc_ver_eq_rc_ver() {
   rerun semver: compare \
@@ -30,9 +30,9 @@ it_ret0_when_rc_ver_eq_rc_ver() {
 }
 
 # ------------------------------
-# X.X.X-(A) != X.X.X-(B)
+# X.X.X-(1) == X.X.X-(2) ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rc_ver_special() {
+it_ret1_when_rc_special_ver_lt_rc_special_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -47,9 +47,26 @@ it_ret1_when_rc_ver_noteq_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A != X.X.(Z)-A
+# X.X.X-(2) == X.X.X-(1) ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rc_ver_patch() {
+it_ret1_when_rc_special_ver_gt_rc_special_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.(1)-Z == X.X.(2)-Z ?
+# ------------------------------
+it_ret1_when_rc_patch_ver_lt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -64,9 +81,26 @@ it_ret1_when_rc_ver_noteq_rc_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A != X.(Z).X-A
+# X.X.(2)-Z == X.X.(1)-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rc_ver_minor() {
+it_ret1_when_rc_patch_ver_gt_rc_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(1).X-Z == X.(2).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -81,14 +115,48 @@ it_ret1_when_rc_ver_noteq_rc_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A != (Z).X.X-A
+# X.(2).X-Z == X.(1).X-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rc_ver_major() {
+it_ret1_when_rc_minor_ver_gt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (1).X.X-Z == (2).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "eq" \
     --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X-Z == (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-4-test.sh
+++ b/tests/compare-4-test.sh
@@ -20,9 +20,9 @@ describe "compare-release-equals-rc"
 #
 
 # ------------------------------
-# X.X.X != X.X.X-(B)
+# X.X.X == X.X.X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rc_ver_special() {
+it_ret1_when_rel_ver_gt_rc_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -37,9 +37,9 @@ it_ret1_when_rel_ver_noteq_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y) != X.X.(Z)-B
+# X.X.(1) == X.X.(2)-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rc_ver_patch() {
+it_ret1_when_rel_patch_ver_lt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -54,9 +54,26 @@ it_ret1_when_rel_ver_noteq_rc_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X != X.(Z).X-B
+# X.X.(2) == X.X.(1)-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rc_ver_minor() {
+it_ret1_when_rel_patch_ver_gt_rc_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(1).X == X.(2).X-Z ?
+# ------------------------------
+it_ret1_when_rel_minor_ver_lt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
@@ -71,14 +88,48 @@ it_ret1_when_rel_ver_noteq_rc_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X != (Z).X.X-B
+# X.(2).X == X.(1).X-Z ?
 # ------------------------------
-it_ret1_when_rel_ver_noteq_rc_ver_major() {
+it_ret1_when_rel_minor_ver_gt_rc_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (1).X.X == (2).X.X-Z ?
+# ------------------------------
+it_ret1_when_rel_major_ver_lt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "eq" \
     --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X == (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rel_major_ver_gt_rc_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-5-test.sh
+++ b/tests/compare-5-test.sh
@@ -20,9 +20,9 @@ describe "compare-rc-equals-release"
 #
 
 # ------------------------------
-# X.X.X-(A) != X.X.X
+# X.X.X-Z == X.X.X ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rel_ver_special() {
+it_ret1_when_rc_ver_lt_rel_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -37,9 +37,9 @@ it_ret1_when_rc_ver_noteq_rel_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A != X.X.(Z)
+# X.X.(1)-Z == X.X.(2) ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rel_ver_patch() {
+it_ret1_when_rc_patch_ver_lt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -54,9 +54,26 @@ it_ret1_when_rc_ver_noteq_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A != X.(Z).X
+# X.X.(2)-Z == X.X.(1) ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rel_ver_minor() {
+it_ret1_when_rc_patch_ver_gt_rel_patch_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.(1).X-Z == X.(2).X ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_lt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
@@ -71,14 +88,48 @@ it_ret1_when_rc_ver_noteq_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A != (Z).X.X
+# X.(2).X-Z == X.(1).X ?
 # ------------------------------
-it_ret1_when_rc_ver_noteq_rel_ver_major() {
+it_ret1_when_rc_minor_ver_gt_rel_minor_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (1).X.X-Z == (2).X.X ?
+# ------------------------------
+it_ret1_when_rc_major_ver_lt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "eq" \
     --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# (2).X.X-Z == (1).X.X ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rel_major_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 1

--- a/tests/compare-6-test.sh
+++ b/tests/compare-6-test.sh
@@ -14,7 +14,7 @@ rerun() {
 # Constants
 
 # invalid semver
-RELEASE_VERSION_THREE_SEVEN="3.7"
+RELEASE_VERSION_TWO_FOUR="2.4"
 
 # The Plan
 # --------
@@ -25,12 +25,63 @@ describe "compare-invalid-releases"
 #
 
 # ------------------------------
-# X.X != X.X.X
+# X.X == X.X ?
 # ------------------------------
-it_ret3_when_left_rel_ver_invalid_equals() {
+it_ret3_when_both_rel_ver_invalid_w_eq() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_THREE_SEVEN" \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "eq" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X < X.X ?
+# ------------------------------
+it_ret3_when_both_rel_ver_invalid_w_lt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X > X.X ?
+# ------------------------------
+it_ret3_when_both_rel_ver_invalid_w_gt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X == X.X.X ?
+# ------------------------------
+it_ret3_when_left_rel_ver_invalid_w_eq() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
     --compare "eq" \
     --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
     echo >&2 "rerun test command succeeded"; return 1
@@ -42,14 +93,48 @@ it_ret3_when_left_rel_ver_invalid_equals() {
 }
 
 # ------------------------------
-# X.X.X != X.X
+# X.X < X.X.X ?
 # ------------------------------
-it_ret3_when_right_rel_ver_invalid_equals() {
+it_ret3_when_left_rel_ver_invalid_w_lt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X > X.X.X ?
+# ------------------------------
+it_ret3_when_left_rel_ver_invalid_w_gt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X == X.X ?
+# ------------------------------
+it_ret3_when_right_rel_ver_invalid_w_eq() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "eq" \
-    --right_version "$RELEASE_VERSION_THREE_SEVEN") && {
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -59,31 +144,14 @@ it_ret3_when_right_rel_ver_invalid_equals() {
 }
 
 # ------------------------------
-# X.X !< X.X.X
+# X.X.X < X.X ?
 # ------------------------------
-it_ret3_when_left_rel_ver_invalid_lt() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_THREE_SEVEN" \
-    --compare "lt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 3
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
-}
-
-# ------------------------------
-# X.X.X !< X.X
-# ------------------------------
-it_ret3_when_right_rel_ver_invalid_lt() {
+it_ret3_when_right_rel_ver_invalid_w_lt() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "lt" \
-    --right_version "$RELEASE_VERSION_THREE_SEVEN") && {
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -93,31 +161,14 @@ it_ret3_when_right_rel_ver_invalid_lt() {
 }
 
 # ------------------------------
-# X.X !> X.X.X
+# X.X.X > X.X ?
 # ------------------------------
-it_ret3_when_left_rel_ver_invalid_gt() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_THREE_SEVEN" \
-    --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 3
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
-}
-
-# ------------------------------
-# X.X.X !> X.X
-# ------------------------------
-it_ret3_when_right_rel_ver_invalid_gt() {
+it_ret3_when_right_rel_ver_invalid_w_gt() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_THREE_SEVEN") && {
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3

--- a/tests/compare-6-test.sh
+++ b/tests/compare-6-test.sh
@@ -76,6 +76,40 @@ it_ret3_when_both_rel_ver_invalid_w_gt() {
 }
 
 # ------------------------------
+# X.X ~> X.X ? pess_patch
+# ------------------------------
+it_ret3_when_both_rel_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X ~> X.X ? pess_minor
+# ------------------------------
+it_ret3_when_both_rel_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
 # X.X == X.X.X ?
 # ------------------------------
 it_ret3_when_left_rel_ver_invalid_w_eq() {
@@ -127,6 +161,40 @@ it_ret3_when_left_rel_ver_invalid_w_gt() {
 }
 
 # ------------------------------
+# X.X ~> X.X.X ? pess_patch
+# ------------------------------
+it_ret3_when_left_rel_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X ~> X.X.X ? pess_minor
+# ------------------------------
+it_ret3_when_left_rel_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR" \
+    --compare "pess_minor" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
 # X.X.X == X.X ?
 # ------------------------------
 it_ret3_when_right_rel_ver_invalid_w_eq() {
@@ -168,6 +236,40 @@ it_ret3_when_right_rel_ver_invalid_w_gt() {
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "gt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X ~> X.X ? pess_patch
+# ------------------------------
+it_ret3_when_right_rel_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "pess_patch" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X ~> X.X ? pess_minor
+# ------------------------------
+it_ret3_when_right_rel_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "pess_minor" \
     --right_version "$RELEASE_VERSION_TWO_FOUR") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-7-test.sh
+++ b/tests/compare-7-test.sh
@@ -76,6 +76,40 @@ it_ret3_when_both_rc_ver_invalid_w_gt() {
 }
 
 # ------------------------------
+# X.X-Z ~> X.X-Z ? pess_patch
+# ------------------------------
+it_ret3_when_both_rc_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X-Z ~> X.X-Z ? pess_minor
+# ------------------------------
+it_ret3_when_both_rc_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
 # X.X-Z == X.X.X-Z ?
 # ------------------------------
 it_ret3_when_left_rc_ver_invalid_w_eq() {
@@ -127,6 +161,40 @@ it_ret3_when_left_rc_ver_invalid_w_gt() {
 }
 
 # ------------------------------
+# X.X-Z ~> X.X.X-Z ? pess_patch
+# ------------------------------
+it_ret3_when_left_rc_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X-Z ~> X.X.X-Z ? pess_minor
+# ------------------------------
+it_ret3_when_left_rc_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "pess_minor" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
 # X.X.X-Z == X.X-Z ?
 # ------------------------------
 it_ret3_when_right_rc_ver_invalid_w_eq() {
@@ -168,6 +236,40 @@ it_ret3_when_right_rc_ver_invalid_w_gt() {
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-Z ~> X.X-Z ? pess_patch
+# ------------------------------
+it_ret3_when_right_rc_ver_invalid_w_pess_patch() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_patch" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-Z ~> X.X-Z ? pess_minor
+# ------------------------------
+it_ret3_when_right_rc_ver_invalid_w_pess_minor() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "pess_minor" \
     --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {

--- a/tests/compare-7-test.sh
+++ b/tests/compare-7-test.sh
@@ -14,7 +14,7 @@ rerun() {
 # Constants
 
 # invalid semver
-RC_VERSION_SIX_TWO_ALPHA_FOUR="6.2-alpha4"
+RC_VERSION_TWO_FOUR_RC_ONE="2.4-rc1"
 
 # The Plan
 # --------
@@ -25,14 +25,14 @@ describe "compare-invalid-rcs"
 #
 
 # ------------------------------
-# X.X-A != X.X.X
+# X.X-Z == X.X-Z ?
 # ------------------------------
-it_ret3_when_left_rc_ver_invalid_equals() {
+it_ret3_when_both_rc_ver_invalid_w_eq() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR" \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
     --compare "eq" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -42,14 +42,48 @@ it_ret3_when_left_rc_ver_invalid_equals() {
 }
 
 # ------------------------------
-# X.X.X != X.X-A
+# X.X-Z < X.X-Z ?
 # ------------------------------
-it_ret3_when_right_rc_ver_invalid_equals() {
+it_ret3_when_both_rc_ver_invalid_w_lt() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X-Z > X.X-Z ?
+# ------------------------------
+it_ret3_when_both_rc_ver_invalid_w_gt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X-Z == X.X.X-Z ?
+# ------------------------------
+it_ret3_when_left_rc_ver_invalid_w_eq() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
     --compare "eq" \
-    --right_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR") && {
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -59,14 +93,14 @@ it_ret3_when_right_rc_ver_invalid_equals() {
 }
 
 # ------------------------------
-# X.X-A !< X.X.X
+# X.X-Z < X.X.X-Z ?
 # ------------------------------
-it_ret3_when_left_rc_ver_invalid_lt() {
+it_ret3_when_left_rc_ver_invalid_w_lt() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR" \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
     --compare "lt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -76,14 +110,48 @@ it_ret3_when_left_rc_ver_invalid_lt() {
 }
 
 # ------------------------------
-# X.X.X !< X.X-A
+# X.X-Z > X.X.X-Z ?
 # ------------------------------
-it_ret3_when_right_rc_ver_invalid_lt() {
+it_ret3_when_left_rc_ver_invalid_w_gt() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --left_version "$RC_VERSION_TWO_FOUR_RC_ONE" \
+    --compare "gt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-Z == X.X-Z ?
+# ------------------------------
+it_ret3_when_right_rc_ver_invalid_w_eq() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "eq" \
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 3
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-Z < X.X-Z ?
+# ------------------------------
+it_ret3_when_right_rc_ver_invalid_w_lt() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "lt" \
-    --right_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR") && {
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3
@@ -93,31 +161,14 @@ it_ret3_when_right_rc_ver_invalid_lt() {
 }
 
 # ------------------------------
-# X.X-A !> X.X.X
+# X.X.X-Z > X.X-Z ?
 # ------------------------------
-it_ret3_when_left_rc_ver_invalid_gt() {
+it_ret3_when_right_rc_ver_invalid_w_gt() {
   local exitcode=
   $(rerun semver: compare \
-    --left_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR" \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "gt" \
-    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
-    echo >&2 "rerun test command succeeded"; return 1
-  } || {
-    exitcode=$?; test $exitcode -eq 3
-  } || {
-    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
-  }
-}
-
-# ------------------------------
-# X.X.X !> X.X-A
-# ------------------------------
-it_ret3_when_right_rc_ver_invalid_gt() {
-  local exitcode=
-  $(rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "gt" \
-    --right_version "$RC_VERSION_SIX_TWO_ALPHA_FOUR") && {
+    --right_version "$RC_VERSION_TWO_FOUR_RC_ONE") && {
     echo >&2 "rerun test command succeeded"; return 1
   } || {
     exitcode=$?; test $exitcode -eq 3

--- a/tests/compare-8-test.sh
+++ b/tests/compare-8-test.sh
@@ -20,9 +20,26 @@ describe "compare-release-less-than-release"
 #
 
 # ------------------------------
-# X.X.(Y) < X.X.(Z)
+# X.X.X < X.X.X ?
 # ------------------------------
-it_ret0_when_rel_ver_lt_rel_ver_patch() {
+it_ret1_when_rel_ver_eq_rel_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_TWO_FOUR_SIX") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.(1) < X.X.(2) ?
+# ------------------------------
+it_ret0_when_rel_patch_ver_lt_rel_patch_ver() {
   rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
     --compare "lt" \
@@ -30,29 +47,9 @@ it_ret0_when_rel_ver_lt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X < X.(Z).X
+# X.X.(2) < X.X.(1) ?
 # ------------------------------
-it_ret0_when_rel_ver_lt_rel_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "lt" \
-    --right_version "$RELEASE_VERSION_TWO_SIX_SIX"
-}
-
-# ------------------------------
-# (Y).X.X < (Z).X.X
-# ------------------------------
-it_ret0_when_rel_ver_lt_rel_ver_major() {
-  rerun semver: compare \
-    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
-    --compare "lt" \
-    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX"
-}
-
-# ------------------------------
-# X.X.(Y) !< X.X.(Z)
-# ------------------------------
-it_ret1_when_rel_ver_notlt_rel_ver_patch() {
+it_ret1_when_rel_patch_ver_gt_rel_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_FOUR_EIGHT" \
@@ -67,9 +64,19 @@ it_ret1_when_rel_ver_notlt_rel_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X !< X.(Z).X
+# X.(1).X < X.(2).X ?
 # ------------------------------
-it_ret1_when_rel_ver_notlt_rel_ver_minor() {
+it_ret0_when_rel_minor_ver_lt_rel_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_TWO_SIX_SIX"
+}
+
+# ------------------------------
+# X.(2).X < X.(1).X ?
+# ------------------------------
+it_ret1_when_rel_minor_ver_gt_rel_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_TWO_SIX_SIX" \
@@ -84,9 +91,19 @@ it_ret1_when_rel_ver_notlt_rel_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X < (Z).X.X
+# (1).X.X < (2).X.X ?
 # ------------------------------
-it_ret1_when_rel_ver_notlt_rel_ver_major() {
+it_ret0_when_rel_major_ver_lt_rel_major_ver() {
+  rerun semver: compare \
+    --left_version "$RELEASE_VERSION_TWO_FOUR_SIX" \
+    --compare "lt" \
+    --right_version "$RELEASE_VERSION_EIGHT_FOUR_SIX"
+}
+
+# ------------------------------
+# (2).X.X < (1).X.X ?
+# ------------------------------
+it_ret1_when_rel_major_ver_gt_rel_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RELEASE_VERSION_EIGHT_FOUR_SIX" \

--- a/tests/compare-9-test.sh
+++ b/tests/compare-9-test.sh
@@ -20,9 +20,26 @@ describe "compare-rc-less-than-rc"
 #
 
 # ------------------------------
-# X.X.X-(A) < X.X.X-(B)
+# X.X.X-Z < X.X.X-Z ?
 # ------------------------------
-it_ret0_when_rc_ver_lt_rc_ver_special() {
+it_ret1_when_rc_ver_eq_rc_ver() {
+  local exitcode=
+  $(rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE") && {
+    echo >&2 "rerun test command succeeded"; return 1
+  } || {
+    exitcode=$?; test $exitcode -eq 1
+  } || {
+    echo >&2 "rerun test command failed with exit code: $exitcode"; return 1
+  }
+}
+
+# ------------------------------
+# X.X.X-(1) < X.X.X-(2) ?
+# ------------------------------
+it_ret0_when_rc_special_ver_lt_rc_special_ver() {
   rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
     --compare "lt" \
@@ -30,39 +47,9 @@ it_ret0_when_rc_ver_lt_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A < X.X.(Z)-B
+# X.X.X-(2) < X.X.X-(1) ?
 # ------------------------------
-it_ret0_when_rc_ver_lt_rc_ver_patch() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE"
-}
-
-# ------------------------------
-# X.(Y).X-A < X.(Z).X-B
-# ------------------------------
-it_ret0_when_rc_ver_lt_rc_ver_minor() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE"
-}
-
-# ------------------------------
-# (Y).X.X-A < (Z).X.X-B
-# ------------------------------
-it_ret0_when_rc_ver_lt_rc_ver_major() {
-  rerun semver: compare \
-    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
-    --compare "lt" \
-    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE"
-}
-
-# ------------------------------
-# X.X.X-(A) !< X.X.X-(B)
-# ------------------------------
-it_ret1_when_rc_ver_notlt_rc_ver_special() {
+it_ret1_when_rc_special_ver_gt_rc_special_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_TWO" \
@@ -77,9 +64,19 @@ it_ret1_when_rc_ver_notlt_rc_ver_special() {
 }
 
 # ------------------------------
-# X.X.(Y)-A !< X.X.(Z)-B
+# X.X.(1)-Z < X.X.(2)-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_notlt_rc_ver_patch() {
+it_ret0_when_rc_patch_ver_lt_rc_patch_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE"
+}
+
+# ------------------------------
+# X.X.(2)-Z < X.X.(1)-Z ?
+# ------------------------------
+it_ret1_when_rc_patch_ver_gt_rc_patch_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_FOUR_EIGHT_RC_ONE" \
@@ -94,9 +91,19 @@ it_ret1_when_rc_ver_notlt_rc_ver_patch() {
 }
 
 # ------------------------------
-# X.(Y).X-A !< X.(Z).X-B
+# X.(1).X-Z < X.(2).X-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_notlt_rc_ver_minor() {
+it_ret0_when_rc_minor_ver_lt_rc_minor_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE"
+}
+
+# ------------------------------
+# X.(2).X-Z < X.(1).X-Z ?
+# ------------------------------
+it_ret1_when_rc_minor_ver_gt_rc_minor_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_TWO_SIX_SIX_RC_ONE" \
@@ -111,9 +118,19 @@ it_ret1_when_rc_ver_notlt_rc_ver_minor() {
 }
 
 # ------------------------------
-# (Y).X.X-A !< (Z).X.X-B
+# (1).X.X-Z < (2).X.X-Z ?
 # ------------------------------
-it_ret1_when_rc_ver_notlt_rc_ver_major() {
+it_ret0_when_rc_major_ver_lt_rc_major_ver() {
+  rerun semver: compare \
+    --left_version "$RC_VERSION_TWO_FOUR_SIX_RC_ONE" \
+    --compare "lt" \
+    --right_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE"
+}
+
+# ------------------------------
+# (2).X.X-Z < (1).X.X-Z ?
+# ------------------------------
+it_ret1_when_rc_major_ver_gt_rc_major_ver() {
   local exitcode=
   $(rerun semver: compare \
     --left_version "$RC_VERSION_EIGHT_FOUR_SIX_RC_ONE" \


### PR DESCRIPTION
198 total tests! 😮 

completed initial api spec for compare

should now fully support `lt`, `gt`, `eq`, `pess_minor`, and `pess_major` matching

versions always must be specified as `semver 2.0.0` compatible (e.g. `0.0.0` or `0.0.0-etc.stuff-42.yadda`)

special and patch versions will be respected by pess matching, e.g. pess minor matching of these versions:

`1.0.0-rc5 ~> 1.0.0-rc6`

...results in a `1`, indicating the left version _does not_ pessimistically match the minor version

this allows you to ensure a lower bound, but still allow to pessimistically match to an upper bound

so e.g. this prevents a bug identified in `rc5` from being accepted, as `rc6` is specified as the minimum, but since we're pess matching on minor, all versions greater or equal to `1.0.0-rc6` and less than `2.0.0` will be accepted

special versions are ASCII sorted... downstream consumers could use `semver: extract` to get the special version from two 'matching' versions, and do their own custom special version comparison if the ASCII comparison is not sufficient